### PR TITLE
Change required numpy version 1.22.3 -> 1.21.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(name='spookynet',
       python_requires=">=3.7",
       install_requires=[
           "ase>=3.22.1",
-          "numpy>=1.22.3",
+          "numpy>=1.21.6",
           "scikit-learn>=1.0.2",
           "torch>=1.11.0",
       ],


### PR DESCRIPTION
The 1.21.6 is the latest version that works with Google Colab (as it runs Python 3.7).